### PR TITLE
Merge fixes to BME280 sensor config

### DIFF
--- a/LILYGO-T-Higrow-ESP32.yaml
+++ b/LILYGO-T-Higrow-ESP32.yaml
@@ -105,6 +105,6 @@ packages:
   waterpump: !include common/waterpump.yaml
   aqi: !include common/bluetooth.yaml
   # Battery only works for 12 hours with deepsleep!
-  # bme280.yaml: !unclude common/bme280.yaml
+  # bme280: !include common/bme280.yaml
   # deepsleep: !include common/deepsleep.yaml
   # battery: !include common/battery.yaml

--- a/common/bme280.yaml
+++ b/common/bme280.yaml
@@ -3,16 +3,16 @@ sensor:
   - platform: bme280
     i2c_id: bus_a
     temperature:
-      name: 'BME280 Temperature'
+      name: '${devicename} BME280 Temperature'
       oversampling: 1x
       # filters: # uncomment after calibration
       #   - offset: -2.3 # offset in °C for the measured temperature
     pressure:
-      name: 'BME280 Pressure'
+      name: '${devicename} BME280 Pressure'
       # filters: # uncomment after calibration
       #   - offset: -2.3 # offset in °C for the measured temperature
     humidity:
-      name: 'BME280 Humidity'
+      name: '${devicename} BME280 Humidity'
       # filters: # uncomment after calibration
       #   - offset: -2.3 # offset in °C for the measured temperature
     address: 0x77

--- a/common/bme280.yaml
+++ b/common/bme280.yaml
@@ -17,3 +17,4 @@ sensor:
       #   - offset: -2.3 # offset in °C for the measured temperature
     address: 0x77
     update_interval: ${update_interval}
+    setup_priority: -300


### PR DESCRIPTION
Fixes #10 by correcting typo in BME280 package definition, adding setup_priority to the package, and adding devicename to the sensor names reported.