### PR TITLE
Fix indentation in deepsleep.yaml

### DIFF
--- a/common/deepsleep.yaml
+++ b/common/deepsleep.yaml
@@ -9,13 +9,13 @@ deep_sleep:
   #   allow_other_uses: true
   #   mode:
   #     input: true
-      # pullup: true
+  #     pullup: true
 
 # Wake Button
 # binary_sensor:
 #   - platform: gpio
 #     name: '${devicename} Wake Button'
-#     pin: 
+#     pin:
 #       number: 35
 #       allow_other_uses: true
 #     internal: true


### PR DESCRIPTION
## Summary
- align `# pullup: true` comment under the `mode:` block
- remove trailing space from `#     pin:` comment line

## Testing
- `yamllint common/deepsleep.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6885029adad88326a5729bf1b33c5853