### PR TITLE
Fix yamllint comment rule in dht.yaml

### DIFF
--- a/common/dht.yaml
+++ b/common/dht.yaml
@@ -3,7 +3,7 @@ sensor:
   # DHT
   - platform: dht
     pin: 16
-    #model: dht11
+    # model: dht11
     temperature:
       name: "${devicename} DHT Temperature"
       unit_of_measurement: "°C"


### PR DESCRIPTION
## Summary
- fix comment spacing for dht sensor configuration

## Testing
- `yamllint -c .github/yamllint.yml common/dht.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6885029a9f7483268abeec0327bcdf29