### PR TITLE
Fix indentation for framework

### DIFF
--- a/LILYGO-T-Higrow-ESP32.yaml
+++ b/LILYGO-T-Higrow-ESP32.yaml
@@ -45,7 +45,7 @@ dashboard_import:
 esp32:
   board: lolin_d32
   framework:
-       type: esp-idf
+    type: esp-idf
 
 improv_serial:
 


### PR DESCRIPTION
## Summary
- fix indentation for the `esp32` framework entry in `LILYGO-T-Higrow-ESP32.yaml`

## Testing
- `yamllint -c .github/yamllint.yml LILYGO-T-Higrow-ESP32.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68850294388c8326a3f06f8ce1e1ce75