### PR TITLE
Fix typos in docs and comments

### DIFF
--- a/LILYGO-T-Higrow-ESP32.yaml
+++ b/LILYGO-T-Higrow-ESP32.yaml
@@ -11,7 +11,7 @@ substitutions:
   conductivity_min: "0.075"
   conductivity_max: "0.25"
   # Uncomment run_duration and sleep_duration if you want to use deepsleep
-  # set how long to stay awake - NOT less then 10sec
+  # set how long to stay awake - NOT less than 10sec
   # run_duration: 11s
   # set how long to sleep in minutes
   # sleep_duration: 60min
@@ -45,7 +45,7 @@ dashboard_import:
 esp32:
   board: lolin_d32
   framework:
-       type: esp-idf
+    type: esp-idf
 
 improv_serial:
 
@@ -61,7 +61,7 @@ wifi:
 
 captive_portal:
 
-# Web server disabled because it was using to much ram
+# Web server disabled because it was using too much RAM
 # web_server:
 # port: 80
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Optionally:
 - LiPo or Li-Ion battery
 - [HACS](https://hacs.xyz/docs/setup/download/)
 - [OpenPlantBook API](https://open.plantbook.io/)
-- [Homeassistant Plantbook intergration](https://github.com/Olen/homeassistant-plant)
-- [Homeassistant Plantbook api intergration](https://github.com/Olen/home-assistant-openplantbook)
+- [Homeassistant Plantbook integration](https://github.com/Olen/homeassistant-plant)
+- [Homeassistant Plantbook API integration](https://github.com/Olen/home-assistant-openplantbook)
 - [Homeassistant Flower card](https://github.com/Olen/lovelace-flower-card/tree/new_plant)
 
 ## How to install (easy)
@@ -37,7 +37,7 @@ This project automates the building process. So all you need to do is open Chrom
 
 ## How to install (expert)
 
-To use this configuration, adjust the [LILYGO-T-Higrow-ESP32.yaml](https://github.com/bruvv/LILYGO-T-Higrow-Esphome/blob/main/LILYGO-T-Higrow-ESP32.yaml) and changes the `Subsitutions`. If you want to adjust specific settings or do a [calibration](https://bruvv.github.io/LILYGO-T-Higrow-Esphome/#how-to-calibrate-the-lilygo-t-higrow-wifi-plant-sensor), the relevant YAML files are in the `common` directory.
+To use this configuration, adjust the [LILYGO-T-Higrow-ESP32.yaml](https://github.com/bruvv/LILYGO-T-Higrow-Esphome/blob/main/LILYGO-T-Higrow-ESP32.yaml) and change the `Substitutions`. If you want to adjust specific settings or do a [calibration](https://bruvv.github.io/LILYGO-T-Higrow-Esphome/#how-to-calibrate-the-lilygo-t-higrow-wifi-plant-sensor), the relevant YAML files are in the `common` directory.
 
 After this, flash the firmware to your device, e.g. with:
 
@@ -53,8 +53,8 @@ To enable the `flower-card` in home-assistant:
 
 1. Get - [OpenPlantBook API](https://open.plantbook.io/)
 2. Install [HACS](https://hacs.xyz/docs/setup/download/)
-3. Install [Homeassistant Plantbook intergration](https://github.com/Olen/homeassistant-plant)
-4. Install [Homeassistant Plantbook api intergration](https://github.com/Olen/home-assistant-openplantbook)
+3. Install [Homeassistant Plantbook integration](https://github.com/Olen/homeassistant-plant)
+4. Install [Homeassistant Plantbook API integration](https://github.com/Olen/home-assistant-openplantbook)
 5. Install [Homeassistant Flower card](https://github.com/Olen/lovelace-flower-card/tree/new_plant)
 
 # Modularity
@@ -77,7 +77,7 @@ If you bought the bme280 sensor option please uncomment `bme280`.
 
 [Deepsleep.yaml](https://github.com/bruvv/LILYGO-T-Higrow-Esphome/blob/main/common/deepsleep.yaml)
 
-If you want to run the battery it is wise to enable this so it will sleep. You can do this in the [LILYGO-T-Higrow-ESP32.yaml](https://github.com/bruvv/LILYGO-T-Higrow-Esphome/blob/main/LILYGO-T-Higrow-ESP32.yaml) by uncommenting the `deepslepp` line.
+If you want to run the battery it is wise to enable this so it will sleep. You can do this in the [LILYGO-T-Higrow-ESP32.yaml](https://github.com/bruvv/LILYGO-T-Higrow-Esphome/blob/main/LILYGO-T-Higrow-ESP32.yaml) by uncommenting the `deepsleep` line.
 
 [dht.yaml](https://github.com/bruvv/LILYGO-T-Higrow-Esphome/blob/main/common/dht.yaml)
 
@@ -89,7 +89,7 @@ This sets up the sensors that go into the soil itself.
 
 [text_sensors.yaml](https://github.com/bruvv/LILYGO-T-Higrow-Esphome/blob/main/common/text_sensors.yaml)
 
-When you want to enable the inbuild text_sensors enable this, it will output usefull stuff to home assistant.
+When you want to enable the inbuilt text_sensors enable this, it will output useful stuff to Home Assistant.
 
 [waterpump.yaml](https://github.com/bruvv/LILYGO-T-Higrow-Esphome/blob/main/common/waterpump.yaml)
 

--- a/static/index.md
+++ b/static/index.md
@@ -1,6 +1,6 @@
 ESPHome firmware for the LILYGO T-Higrow WIFI Plant Sensor
 
-![LILYGO-T-Higrow-ESP32-Soil-Tester-DHT11-BEM280-Garden-Flowers-Temperature-Moisture-Sensor-WiFi-Bluetooth-Wireless jpg_Q90](https://user-images.githubusercontent.com/3063928/206154094-ab7eba28-10b1-4b91-85e5-5729495d6a8d.jpg)
+![LILYGO-T-Higrow-ESP32-Soil-Tester-DHT11-BME280-Garden-Flowers-Temperature-Moisture-Sensor-WiFi-Bluetooth-Wireless jpg_Q90](https://user-images.githubusercontent.com/3063928/206154094-ab7eba28-10b1-4b91-85e5-5729495d6a8d.jpg)
 
 ![183286657-824a0e7f-a140-4d8e-8d6a-387070419dfd](https://user-images.githubusercontent.com/3063928/206154221-49a0d3ce-1850-4154-9039-1633d4962cd5.png)
 
@@ -20,8 +20,8 @@ To enable the flower-card in home-assistant:
 
 1. Get - [OpenPlantBook API](https://open.plantbook.io)
 2. Install [HACS](https://hacs.xyz/docs/setup/download)
-3. Install [Homeassistant Plantbook intergration](https://github.com/Olen/homeassistant-plant)
-4. Install [Homeassistant Plantbook api intergration](https://github.com/Olen/home-assistant-openplantbook)
+3. Install [Homeassistant Plantbook integration](https://github.com/Olen/homeassistant-plant)
+4. Install [Homeassistant Plantbook API integration](https://github.com/Olen/home-assistant-openplantbook)
 5. Install [Homeassistant Flower card](https://github.com/Olen/lovelace-flower-card/tree/new_plant)
 
 # How to Calibrate the LILYGO T-Higrow Wi-Fi Plant Sensor


### PR DESCRIPTION
## Summary
- fix 'integration' typo across docs
- fix 'Substitutions' reference in README
- correct additional spelling mistakes in documentation and YAML comments

## Testing
- `yamllint -c .github/yamllint.yml LILYGO-T-Higrow-ESP32.yaml common/`

------
https://chatgpt.com/codex/tasks/task_e_6885029c000083268d4ad0e29413c3fa